### PR TITLE
Fix: Handle pysqlite3 import and sys.modules manipulation more robustly

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,9 +8,17 @@ from telebot import telebot, types
 from sentence_transformers import SentenceTransformer
 from huggingface_hub import login
 
-__import__('pysqlite3')
 import sys
-sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
+
+try:
+    __import__('pysqlite3')
+    if 'pysqlite3' in sys.modules:
+        sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
+        print("INFO: Successfully swapped sqlite3 with pysqlite3.")
+    else:
+        print("WARNING: pysqlite3 was imported but not found in sys.modules. Skipping swap.")
+except ImportError:
+    print("WARNING: pysqlite3 could not be imported. Using system's default sqlite3.")
 
 import chromadb
 from chromadb.utils import embedding_functions


### PR DESCRIPTION
The application was encountering a KeyError for 'pysqlite3' when deployed on Streamlit, indicating an issue with the module's availability or import process.

This commit introduces the following changes to app.py:
- Wraps the `__import__('pysqlite3')` call in a try-except ImportError block.
- If `pysqlite3` is imported successfully, it checks if 'pysqlite3' is present in `sys.modules` before attempting to pop it and assign it to `sys.modules['sqlite3']`.
- Adds print statements (acting as logs) to provide information on whether the import and swap were successful, or if `pysqlite3` could not be imported.

This makes the application more resilient to the absence of `pysqlite3` and helps diagnose if the module is not being correctly installed or made available in the Streamlit environment.